### PR TITLE
Validating stored canton data

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.2.5",
+  "version": "2.2.6",
   "dependencies": {
     "@sentry/webpack-plugin": "^1.5.2",
     "autoprefixer": "^8.6.4",

--- a/server/swissvoice/__info__.py
+++ b/server/swissvoice/__info__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "1.2.3"
+__version__ = "1.2.4"

--- a/server/swissvoice/swissvoice.py
+++ b/server/swissvoice/swissvoice.py
@@ -36,6 +36,15 @@ def get_regions() -> Response:
     return response(regions=regions)
 
 
+@app.route("/api/regions/verify/<oid:region>")
+def check_region(region: ObjectId) -> Response:
+    document = proxy.regions_coll.find_one(region)
+    if document:
+        return response(cantons=document.get("cantons", []))
+    else:
+        return error_response(Error.REGION_INVALID, "This region doesn't exist!")
+
+
 @app.route("/api/text/<oid:region>", methods=["GET"])
 def get_text(region: ObjectId) -> Response:
     count = cast_type(int, request.args.get("count"), 3)

--- a/server/swissvoice/utils.py
+++ b/server/swissvoice/utils.py
@@ -22,6 +22,8 @@ class Error(IntEnum):
     GENERAL = 0
     INVALID_REQUEST = 1
 
+    REGION_INVALID = 101
+
     NO_TEXT_FOUND = 1001
 
     NO_SAMPLE_FOUND = 2001

--- a/src/js/api.js
+++ b/src/js/api.js
@@ -76,9 +76,34 @@ export default (() => {
         extractCantons();
     }
 
+    async function verifyCanton(canton) {
+        if (canton.region && canton.name && canton.image) {
+            const url = buildUrl("api", "regions", "verify", canton.region);
+            let resp;
+
+            try {
+                resp = await $.getJSON(url);
+            } catch (e) {
+                return false;
+            }
+
+            if (resp.success) {
+                if (resp.cantons.indexOf(canton.name) >= 0) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
     async function setup(canton, apiDomain) {
         if (!canton) {
             canton = JSON.parse(localStorage.getItem("canton"));
+            const valid = await verifyCanton(canton);
+            if (!valid) {
+                canton = null;
+            }
         }
         if (canton) {
             currentCanton = canton;

--- a/src/js/api.js
+++ b/src/js/api.js
@@ -87,10 +87,8 @@ export default (() => {
                 return false;
             }
 
-            if (resp.success) {
-                if (resp.cantons.indexOf(canton.name) >= 0) {
-                    return true;
-                }
+            if (resp.success && resp.cantons.indexOf(canton.name) >= 0) {
+                return true;
             }
         }
 


### PR DESCRIPTION
###### Fixes [FRONTENT-Q](https://sentry.io/swiss-voice/frontend/issues/607253428/)

### Behaviour
Code verifies that there's a canton object stored which has the properties `region`, `name` and `image`. It then asks the server whether there is such a region and ensures that this specific canton is part of it. *There's no validation for the image because it would require a cross-database lookup which is too resource-intensive*
